### PR TITLE
Update to 1.13 and fix removed AuthLib API

### DIFF
--- a/bungeeguard-backend/pom.xml
+++ b/bungeeguard-backend/pom.xml
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>com.destroystokyo.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.12.1-R0.1-SNAPSHOT</version>
+            <version>${paper.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.10</version>
+            <version>${lombok.version}</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/bungeeguard-backend/pom.xml
+++ b/bungeeguard-backend/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>me.lucko</groupId>
         <artifactId>bungeeguard</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bungeeguard-backend</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
 
     <build>
         <defaultGoal>clean package</defaultGoal>

--- a/bungeeguard-backend/pom.xml
+++ b/bungeeguard-backend/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>me.lucko</groupId>
         <artifactId>bungeeguard</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bungeeguard-backend</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <build>
         <defaultGoal>clean package</defaultGoal>

--- a/bungeeguard-backend/src/main/java/me/lucko/bungeeguard/backend/BungeeGuardBackendPlugin.java
+++ b/bungeeguard-backend/src/main/java/me/lucko/bungeeguard/backend/BungeeGuardBackendPlugin.java
@@ -1,13 +1,11 @@
 package me.lucko.bungeeguard.backend;
 
-import lombok.Getter;
-
 import com.destroystokyo.paper.event.player.PlayerHandshakeEvent;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-import com.mojang.authlib.properties.Property;
-
+import lombok.Getter;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.EventHandler;
@@ -27,7 +25,7 @@ import java.util.UUID;
  * The token is included within the player's profile properties, but removed during the handshake.
  */
 public class BungeeGuardBackendPlugin extends JavaPlugin implements Listener {
-    private static final Type PROPERTY_LIST_TYPE = new TypeToken<List<Property>>(){}.getType();
+    private static final Type PROPERTY_LIST_TYPE = new TypeToken<List<JsonObject>>(){}.getType();
 
     @Getter
     private final Gson gson = new Gson();
@@ -78,7 +76,7 @@ public class BungeeGuardBackendPlugin extends JavaPlugin implements Listener {
         }
 
         // deserialize the properties in the handshake
-        List<Property> properties = gson.fromJson(split[3], PROPERTY_LIST_TYPE);
+        List<JsonObject> properties = gson.fromJson(split[3], PROPERTY_LIST_TYPE);
 
         // fail if no properties
         if (properties.isEmpty()) {
@@ -91,9 +89,9 @@ public class BungeeGuardBackendPlugin extends JavaPlugin implements Listener {
         String token = null;
 
         // try to find the token
-        for (Property property : properties) {
-            if (property.getName().equals("bungeeguard-token")) {
-                token = property.getValue();
+        for (JsonObject property : properties) {
+            if (property.get("name").getAsString().equals("bungeeguard-token")) {
+                token = property.get("value").getAsString();
                 break;
             }
         }
@@ -114,9 +112,9 @@ public class BungeeGuardBackendPlugin extends JavaPlugin implements Listener {
         }
 
         // create a new properties array, without our token
-        List<Property> newProperties = new ArrayList<>();
-        for (Property property : properties) {
-            if (property.getName().equals("bungeeguard-token")) {
+        List<JsonObject> newProperties = new ArrayList<>();
+        for (JsonObject property : properties) {
+            if (property.get("name").getAsString().equals("bungeeguard-token")) {
                 continue;
             }
 

--- a/bungeeguard-backend/src/main/resources/plugin.yml
+++ b/bungeeguard-backend/src/main/resources/plugin.yml
@@ -1,3 +1,4 @@
 name: BungeeGuard
 version: ${project.version}
 main: me.lucko.bungeeguard.backend.BungeeGuardBackendPlugin
+api-version: 1.13

--- a/bungeeguard-proxy/pom.xml
+++ b/bungeeguard-proxy/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>${bungee.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-proxy</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>${bungee.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.10</version>
+            <version>${lombok.version}</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/bungeeguard-proxy/pom.xml
+++ b/bungeeguard-proxy/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>me.lucko</groupId>
         <artifactId>bungeeguard</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bungeeguard-proxy</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <build>
         <defaultGoal>clean package</defaultGoal>

--- a/bungeeguard-proxy/pom.xml
+++ b/bungeeguard-proxy/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>me.lucko</groupId>
         <artifactId>bungeeguard</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bungeeguard-proxy</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
 
     <build>
         <defaultGoal>clean package</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <paper.version>1.13-R0.1-SNAPSHOT</paper.version>
+        <bungee.version>1.13-SNAPSHOT</bungee.version>
+        <lombok.version>1.16.10</lombok.version>
+
         <compiler.version>3.6.1</compiler.version>
         <shade.version>3.0.0</shade.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>bungeeguard</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -21,10 +21,10 @@
 
         <paper.version>1.13-R0.1-SNAPSHOT</paper.version>
         <bungee.version>1.13-SNAPSHOT</bungee.version>
-        <lombok.version>1.16.10</lombok.version>
+        <lombok.version>1.18.0</lombok.version>
 
-        <compiler.version>3.6.1</compiler.version>
-        <shade.version>3.0.0</shade.version>
+        <compiler.version>3.7.0</compiler.version>
+        <shade.version>3.1.1</shade.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lucko</groupId>
     <artifactId>bungeeguard</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
In Paper 1.13, the deprecated AuthLib API was removed in [this commit](https://github.com/PaperMC/Paper/commit/e64513b585e490cb6ba17a2524f1f0a889ad3e85).

I also moved the version strings to the main pom.xml under "properties"

Changes and suggestions are welcome