### PR TITLE
Shutdown server and send info when an incompatible server is found

### DIFF
--- a/bungeeguard-backend/src/main/java/me/lucko/bungeeguard/backend/BungeeGuardBackendPlugin.java
+++ b/bungeeguard-backend/src/main/java/me/lucko/bungeeguard/backend/BungeeGuardBackendPlugin.java
@@ -38,6 +38,21 @@ public class BungeeGuardBackendPlugin extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
+        try {
+            Class.forName("com.destroystokyo.paper.event.player.PlayerHandshakeEvent");
+        } catch (ClassNotFoundException e1) {
+            getLogger().severe("Server " + getServer().getName() + " " + getServer().getBukkitVersion() + " is incompatible with this plugin!");
+            try {
+                Class.forName("com.destroystokyo.paper.PaperConfig");
+                getLogger().info("Your server is too old and does not have the required API, please update!");
+            } catch (ClassNotFoundException e2) {
+                getLogger().info("You are running a server type which does not provide the required API.");
+                getLogger().info("Please install a recent version of Paper! For more info visit https://papermc.io");
+            }
+            getLogger().info("Shutting down the server to be safe!");
+            getServer().shutdown();
+            return;
+        }
         getLogger().info("Using Paper PlayerHandshakeEvent");
         getServer().getPluginManager().registerEvents(this, this);
 


### PR DESCRIPTION
This checks if the installed server type and version is compatible with the plugin and if not sends some informative messages regarding the situation (by trying to detect if it's an outdated paper version or a non-paper one) and shuts down the server so that it's not possible to be run under a false sense of security.

Currently the error that gets send when the event wasn't found seems to be [rather cryptic](https://media.discordapp.net/attachments/555469074080202765/705785395563987064/unknown.png) to end users, hence this change.