### PR TITLE
Sanitize log messages

### DIFF
--- a/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/BungeeCordHandshake.java
+++ b/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/BungeeCordHandshake.java
@@ -30,6 +30,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,7 +67,7 @@ public class BungeeCordHandshake {
             return decodeAndVerify0(handshake, tokenStore);
         } catch (Exception e) {
             new Exception("Failed to decode handshake", e).printStackTrace();
-            return new Fail(Fail.Reason.INVALID_HANDSHAKE, handshake);
+            return new Fail(Fail.Reason.INVALID_HANDSHAKE, encodeBase64(handshake));
         }
     }
 
@@ -76,14 +78,14 @@ public class BungeeCordHandshake {
 
         String[] split = handshake.split("\00");
         if (split.length != 3 && split.length != 4) {
-            return new Fail(Fail.Reason.INVALID_HANDSHAKE, handshake);
+            return new Fail(Fail.Reason.INVALID_HANDSHAKE, encodeBase64(handshake));
         }
 
         String serverHostname = split[0];
         String socketAddressHostname = split[1];
         UUID uniqueId = UUID.fromString(split[2].replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
 
-        String connectionDescription = uniqueId + " @ " + socketAddressHostname;
+        String connectionDescription = uniqueId + " @ " + encodeBase64(socketAddressHostname);
 
         if (split.length == 3) {
             return new Fail(Fail.Reason.NO_TOKEN, connectionDescription);
@@ -112,11 +114,15 @@ public class BungeeCordHandshake {
         }
 
         if (!tokenStore.isAllowed(bungeeGuardToken)) {
-            return new Fail(Fail.Reason.INCORRECT_TOKEN, connectionDescription + " - " + bungeeGuardToken);
+            return new Fail(Fail.Reason.INCORRECT_TOKEN, connectionDescription + " - " + encodeBase64(bungeeGuardToken));
         }
 
         String newPropertiesString = GSON.toJson(properties, PROPERTY_LIST_TYPE);
         return new Success(serverHostname, socketAddressHostname, uniqueId, newPropertiesString);
+    }
+    
+    public static String encodeBase64(String s) {
+        return Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/listener/ProtocolHandshakeListener.java
+++ b/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/listener/ProtocolHandshakeListener.java
@@ -44,6 +44,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import java.net.InetSocketAddress;
 import java.util.logging.Logger;
 
 /**
@@ -77,8 +78,16 @@ public class ProtocolHandshakeListener extends AbstractHandshakeListener {
             BungeeCordHandshake decoded = BungeeCordHandshake.decodeAndVerify(handshake, ProtocolHandshakeListener.this.tokenStore);
 
             if (decoded instanceof BungeeCordHandshake.Fail) {
+                String ip = "null";
+                InetSocketAddress address = event.getPlayer().getAddress();
+                if (address != null) {
+                    ip = address.getHostString();
+                    if (ip.length() > 15) {
+                        ip = BungeeCordHandshake.encodeBase64(ip);
+                    }
+                }
                 BungeeCordHandshake.Fail fail = (BungeeCordHandshake.Fail) decoded;
-                ProtocolHandshakeListener.this.logger.warning("Denying connection from " + fail.describeConnection() + " - reason: " + fail.reason().name());
+                ProtocolHandshakeListener.this.logger.warning("Denying connection from " + ip + " - " + fail.describeConnection() + " - reason: " + fail.reason().name());
 
                 String kickMessage;
                 if (fail.reason() == BungeeCordHandshake.Fail.Reason.INVALID_HANDSHAKE) {


### PR DESCRIPTION
Prevent invalid hostname data from getting written to the log as-is to prevent faking log messages. Base64 encoding is a good solution for that. Additionally try to fetch the actual connecting ip address if possible and log it.

This is exploited currently (this is no exploit specific to BungeeGuard tho).