### PR TITLE
Support new BungeeCord API

### DIFF
--- a/bungeeguard-bungee-java9/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResultJava9.java
+++ b/bungeeguard-bungee-java9/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResultJava9.java
@@ -26,6 +26,7 @@
 package me.lucko.bungeeguard.bungee;
 
 import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.protocol.Property;
 
 public class SpoofedLoginResultJava9 extends SpoofedLoginResult {
     private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);

--- a/bungeeguard-bungee/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResult.java
+++ b/bungeeguard-bungee/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResult.java
@@ -28,6 +28,7 @@ package me.lucko.bungeeguard.bungee;
 import net.md_5.bungee.ServerConnector;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.protocol.Property;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;

--- a/bungeeguard-bungee/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResultJava8.java
+++ b/bungeeguard-bungee/src/main/java/me/lucko/bungeeguard/bungee/SpoofedLoginResultJava8.java
@@ -28,6 +28,7 @@ package me.lucko.bungeeguard.bungee;
 import net.md_5.bungee.connection.LoginResult;
 
 import jdk.internal.reflect.Reflection;
+import net.md_5.bungee.protocol.Property;
 
 public class SpoofedLoginResultJava8 extends SpoofedLoginResult {
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <paper.version>1.15.2-R0.1-SNAPSHOT</paper.version>
-        <bungee.version>1.15-SNAPSHOT</bungee.version>
+        <bungee.version>1.19-R0.1-SNAPSHOT</bungee.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Fixes the issue for:
`java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
        at me.lucko.bungeeguard.bungee.SpoofedLoginResult.inject(SpoofedLoginResult.java:83) ~[?:?]
        at me.lucko.bungeeguard.bungee.BungeeGuardProxyPlugin.onLogin(BungeeGuardProxyPlugin.java:110) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:567) ~[?:?]
        at net.md_5.bungee.event.EventHandlerMethod.invoke(EventHandlerMethod.java:20) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.event.EventBus.post(EventBus.java:51) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.api.plugin.PluginManager.callEvent(PluginManager.java:418) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.connection.InitialHandler.finish(InitialHandler.java:550) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.connection.InitialHandler.lambda$handle$3(InitialHandler.java:470) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.http.HttpHandler.done(HttpHandler.java:69) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.http.HttpHandler.channelRead0(HttpHandler.java:60) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at net.md_5.bungee.http.HttpHandler.channelRead0(HttpHandler.java:15) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1371) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1234) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1283) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[Waterfall1.19.nuevo.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:001e21d:unknown]
        at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.reflect.InvocationTargetException
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:78) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at me.lucko.bungeeguard.bungee.SpoofedLoginResult.inject(SpoofedLoginResult.java:80) ~[?:?]
        ... 47 more
Caused by: java.lang.NoSuchMethodError: 'net.md_5.bungee.connection.LoginResult$Property[] net.md_5.bungee.connection.LoginResult.getProperties()'
        at me.lucko.bungeeguard.bungee.SpoofedLoginResult.<init>(SpoofedLoginResult.java:99) ~[?:?]
        at me.lucko.bungeeguard.bungee.SpoofedLoginResultJava9.<init>(SpoofedLoginResultJava9.java:36) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:78) ~[?:?]
        at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
        at me.lucko.bungeeguard.bungee.SpoofedLoginResult.inject(SpoofedLoginResult.java:80) ~[?:?]
        ... 47 more`