### PR TITLE
Include resources into jar

### DIFF
--- a/bungeeguard-sponge/pom.xml
+++ b/bungeeguard-sponge/pom.xml
@@ -23,7 +23,11 @@
                 </includes>
             </resource>
             <resource>
-                <directory>src/main/resources</directory>
+                <directory>${project.basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>*.conf</include>
+                </includes>
             </resource>
         </resources>
         <plugins>

--- a/bungeeguard-sponge/pom.xml
+++ b/bungeeguard-sponge/pom.xml
@@ -22,6 +22,9 @@
                     <include>LICENSE.txt</include>
                 </includes>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
         </resources>
         <plugins>
             <plugin>


### PR DESCRIPTION
Fixes issue #71 by including the resources folder into the packaged jar for the Sponge edition. The default bungeeguard.conf could not be found on loadup, resulting in the plugin not loading.