### PR TITLE
Fix Spigot Compatibility

### DIFF
--- a/bungeeguard-bungee-java9/pom.xml
+++ b/bungeeguard-bungee-java9/pom.xml
@@ -29,12 +29,24 @@
             <artifactId>bungeecord-api</artifactId>
             <version>${bungee.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-proxy</artifactId>
             <version>${bungee.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/bungeeguard-bungee/pom.xml
+++ b/bungeeguard-bungee/pom.xml
@@ -30,12 +30,24 @@
             <artifactId>bungeecord-api</artifactId>
             <version>${bungee.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-proxy</artifactId>
             <version>${bungee.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/BungeeGuardBackendPlugin.java
+++ b/bungeeguard-spigot/src/main/java/me/lucko/bungeeguard/spigot/BungeeGuardBackendPlugin.java
@@ -54,7 +54,7 @@ public class BungeeGuardBackendPlugin extends JavaPlugin implements BungeeGuardB
         this.tokenStore = new TokenStore(this);
         this.tokenStore.load();
 
-        if (!getServer().spigot().getSpigotConfig().getBoolean("settings.bungeecord", false)) {
+        if (!getServer().spigot().getConfig().getBoolean("settings.bungeecord", false)) {
             getLogger().severe("------------------------------------------------------------");
             getLogger().severe("'settings.bungeecord' is set to false in spigot.yml.");
             getLogger().severe("");

--- a/bungeeguard-sponge/pom.xml
+++ b/bungeeguard-sponge/pom.xml
@@ -63,7 +63,7 @@
     <repositories>
         <repository>
             <id>sponge-repo</id>
-            <url>https://repo.spongepowered.org/maven/</url>
+            <url>https://repo.spongepowered.org/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         </repository>
         <repository>
             <id>paper-repo</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>luck-repo</id>


### PR DESCRIPTION
Fixes spigot compatibility issue

discord message: https://discord.com/channels/438081365620293636/836330941491445870/1088228102276132994

Tested on 695-Spigot-6ad4b93-2d5209e (MC: 1.19.4) & git-Paper-466 (MC: 1.19.4)

No idea why I had to exclude netty, but I was unable to build without excluding it.